### PR TITLE
feat(memos): host usememos behind nginx and cloudflare tunnel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,15 @@ services:
     networks:
       - home-network
 
+  # Memos - lightweight note taking / memo hub
+  memos:
+    image: neosmemo/memos:stable
+    volumes:
+      - memos-data:/var/opt/memos
+    networks:
+      - home-network
+    restart: always
+
 networks:
   home-network:
     name: home-network
@@ -85,3 +94,4 @@ volumes:
   influxdb2-data:
   influxdb2-config:
   prometheus-tsdb:
+  memos-data:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,8 @@
 http {
+    upstream memos {
+        server memos:5230;
+    }
+
     upstream grafana {
         server grafana:3000;
     }
@@ -10,6 +14,20 @@ http {
 
         location / {
             proxy_pass http://grafana;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    server {
+        listen 80;
+
+        server_name memos.sor4chi.com;
+
+        location / {
+            proxy_pass http://memos;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## どういう変更か

compose スタックに usememos の `memos` サービスを追加し、`memos.sor4chi.com` を nginx 経由で公開する。

- `docker-compose.yml`: `neosmemo/memos:stable` を `home-network` 上に追加。データは named volume `memos-data` を `/var/opt/memos` にマウントして永続化、`restart: always`。
- `nginx/nginx.conf`: `upstream memos { server memos:5230; }` と `server_name memos.sor4chi.com` のプロキシブロックを追加。`monitor.sor4chi.com` と同じ構成に揃えている。

## なぜ変更するのか

メモ用途の self-host 環境としてホームサーバー上に memos を常設したいため。既存の `*.sor4chi.com` proxy 運用（nginx + Cloudflare Tunnel）にそのまま乗せられる。

## 追加の情報

外部公開に必要な Cloudflare Tunnel の public hostname (`memos.sor4chi.com`) は dashboard 側で追加済みで、本番から疎通確認済み。この diff には含まれない（token 方式トンネルのため設定はリポジトリ外）。