### PR TITLE
feat(memos): add nightly restic backup of memos to cloudflare r2

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,11 @@
+FROM restic/restic:latest
+
+# sqlite3: SQLite を停止せず online backup API で整合スナップショットを取るため
+# tzdata: cron を JST 等のローカル時刻で動かすため
+RUN apk add --no-cache sqlite tzdata
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/backup.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,0 +1,61 @@
+# memos backup (restic → Cloudflare R2)
+
+memos のデータ（SQLite `memos_prod.db` と assets）を毎日 Cloudflare R2 へ
+restic で暗号化・増分バックアップする常駐コンテナ。
+
+## 仕組み
+
+- `backup.sh` が SQLite を **オンラインバックアップ API** で整合スナップショット化（memos 無停止）し、restic で R2 に送る。
+- 保持ポリシーは日次7 / 週次4 / 月次6。`restic forget --prune` で自動整理。
+- スケジュールは `BACKUP_CRON`（デフォルト `0 4 * * *` = 毎日 04:00 JST）。
+
+## セットアップ
+
+### 1. Cloudflare R2 を用意
+
+1. Cloudflare ダッシュボード → R2 → **Create bucket**（例: `memos-backup`）
+2. R2 → **Manage R2 API Tokens** → **Create API token**
+   - Permissions: **Object Read & Write**、対象を該当バケットに限定
+   - 発行された **Access Key ID** / **Secret Access Key** を控える
+3. Account ID（R2 概要ページ右側、または S3 エンドポイント `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`）を控える
+
+### 2. secrets を埋める
+
+```bash
+cp secrets/.env.r2.example secrets/.env.r2
+cp secrets/.env.restic-password.example secrets/.env.restic-password
+
+# .env.r2 を編集（ACCOUNT_ID / バケット名 / R2 キー）
+# restic の暗号化パスフレーズを生成
+openssl rand -base64 32 > secrets/.env.restic-password
+```
+
+> **重要**: `secrets/.env.restic-password` を失うと **復元不能**。
+> パスワードマネージャ等、このサーバー以外の場所にも必ず控える。
+
+### 3. 起動と初回バックアップ
+
+```bash
+docker compose build memos-backup
+# 初回だけ即時実行してリポジトリ初期化＋1世代取得を確認
+RUN_ON_START=true docker compose run --rm memos-backup
+# 問題なければ常駐起動
+docker compose up -d memos-backup
+docker compose logs -f memos-backup
+```
+
+## 運用コマンド
+
+```bash
+# 世代一覧
+docker compose run --rm memos-backup snapshots
+
+# リポジトリ健全性チェック
+docker compose run --rm memos-backup check
+
+# 復元（最新世代を /restore に展開）※ restore.sh 参照
+docker compose run --rm -v "$PWD/restore:/restore" memos-backup \
+  restore latest --target /restore
+```
+
+復元手順の詳細は `restore.sh` を参照。

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# memos のデータを Cloudflare R2 へ restic でバックアップする。
+# - SQLite はオンラインバックアップ API で整合スナップショットを取る（memos 無停止）
+# - assets 等その他ファイルは /data からそのまま取り込む
+# - 取得後に保持ポリシーで世代を整理する
+set -eu
+
+DB=/data/memos_prod.db
+SNAP=/snapshot
+
+echo "[backup] $(date '+%F %T') start"
+
+rm -rf "$SNAP"
+mkdir -p "$SNAP"
+
+if [ -f "$DB" ]; then
+  # online backup: memos が書き込み中でも整合した断面を取得できる
+  sqlite3 "$DB" ".backup '$SNAP/memos_prod.db'"
+  echo "[backup] sqlite consistent snapshot OK ($(du -h "$SNAP/memos_prod.db" | cut -f1))"
+else
+  echo "[backup] WARN: $DB not found (memos が未初期化か、DB 名が異なる可能性)"
+fi
+
+# リポジトリ未初期化なら初期化（暗号化リポジトリを R2 上に作成）
+if ! restic snapshots >/dev/null 2>&1; then
+  echo "[backup] initializing restic repository"
+  restic init
+fi
+
+# 整合スナップショットの DB と、それ以外の実体（assets 等）を取り込む。
+# ライブの memos_prod.db* は不整合な断面になりうるので除外する。
+restic backup "$SNAP" /data \
+  --tag memos \
+  --exclude "$DB" \
+  --exclude "${DB}-wal" \
+  --exclude "${DB}-shm"
+
+# 保持ポリシー: 日次7 / 週次4 / 月次6。古い世代は prune で物理削除。
+restic forget --prune \
+  --keep-daily 7 \
+  --keep-weekly 4 \
+  --keep-monthly 6
+
+echo "[backup] $(date '+%F %T') done"

--- a/backup/entrypoint.sh
+++ b/backup/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# memos のバックアップ常駐コンテナのエントリポイント。
+#
+# 使い方:
+#   引数なし         -> BACKUP_CRON のスケジュールで backup.sh を回す常駐モード
+#   backup-now       -> 即時に一度だけバックアップして終了（初回確認・手動実行用）
+#   それ以外の引数    -> restic にそのまま渡す（例: snapshots / check / restore ...）
+set -eu
+
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    backup-now) exec /usr/local/bin/backup.sh ;;
+    *) exec restic "$@" ;;
+  esac
+fi
+
+: "${BACKUP_CRON:=0 4 * * *}"
+
+# cron ジョブの出力をコンテナ標準出力/標準エラー (crond=PID1) に流す
+echo "$BACKUP_CRON /usr/local/bin/backup.sh >/proc/1/fd/1 2>/proc/1/fd/2" > /etc/crontabs/root
+echo "[entrypoint] scheduled backup: '$BACKUP_CRON' (TZ=${TZ:-UTC})"
+
+# 常駐起動時に一度だけ実行したい場合は RUN_ON_START=true
+if [ "${RUN_ON_START:-false}" = "true" ]; then
+  echo "[entrypoint] RUN_ON_START=true -> running once now"
+  /usr/local/bin/backup.sh || echo "[entrypoint] initial backup failed (will retry on schedule)"
+fi
+
+exec crond -f -l 8

--- a/backup/restore.sh
+++ b/backup/restore.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# memos バックアップの復元ヘルパー（ホスト側で実行する想定の手順メモ兼スクリプト）。
+#
+# 復元は「R2 から restic で取り出す -> memos を止めて DB を差し替える -> 起動」。
+# データ破壊を避けるため、対話確認を挟む。
+#
+# 使い方:
+#   ./restore.sh            最新世代を ./restore/ に展開するだけ（安全・確認用）
+#   ./restore.sh apply      展開後、memos を停止して memos_prod.db を本番へ反映
+set -eu
+
+cd "$(dirname "$0")/.."   # repo ルートへ
+OUT=./restore
+
+echo "[restore] 最新スナップショットを $OUT/ に展開します"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+docker compose run --rm -v "$PWD/restore:/restore" memos-backup \
+  restore latest --target /restore
+
+echo "[restore] 展開結果:"
+find "$OUT" -maxdepth 3 -type f
+
+if [ "${1:-}" != "apply" ]; then
+  echo
+  echo "[restore] 確認のみ完了。本番へ反映するには: ./backup/restore.sh apply"
+  exit 0
+fi
+
+DB_SRC="$OUT/snapshot/memos_prod.db"
+if [ ! -f "$DB_SRC" ]; then
+  echo "[restore] ERROR: $DB_SRC が見つかりません。中断します。" >&2
+  exit 1
+fi
+
+printf '[restore] memos を停止して DB を差し替えます。よろしいですか? [y/N] '
+read -r ans
+[ "$ans" = "y" ] || { echo "中断しました"; exit 1; }
+
+docker compose stop memos
+# 名前付きボリュームへ DB を書き戻す（ヘルパーコンテナ経由）
+docker run --rm -v sor4chicom_memos-data:/data -v "$PWD/$OUT/snapshot:/src:ro" alpine \
+  sh -c "cp /src/memos_prod.db /data/memos_prod.db && rm -f /data/memos_prod.db-wal /data/memos_prod.db-shm"
+docker compose start memos
+echo "[restore] 反映完了。memos の表示を確認してください。"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,22 @@ services:
       - home-network
     restart: always
 
+  # Off-site backup of memos data to Cloudflare R2 (restic)
+  memos-backup:
+    build: ./backup
+    env_file:
+      - ./secrets/.env.r2
+    environment:
+      RESTIC_PASSWORD_FILE: /run/secrets/restic-password
+      TZ: Asia/Tokyo
+      BACKUP_CRON: "0 4 * * *"
+    volumes:
+      - memos-data:/data:ro
+      - restic-cache:/root/.cache/restic
+    secrets:
+      - restic-password
+    restart: always
+
 networks:
   home-network:
     name: home-network
@@ -88,6 +104,8 @@ secrets:
     file: ./secrets/.env.influxdb2-admin-password
   influxdb2-admin-token:
     file: ./secrets/.env.influxdb2-admin-token
+  restic-password:
+    file: ./secrets/.env.restic-password
 
 volumes:
   grafana-storage:
@@ -95,3 +113,4 @@ volumes:
   influxdb2-config:
   prometheus-tsdb:
   memos-data:
+  restic-cache:

--- a/secrets/.env.r2.example
+++ b/secrets/.env.r2.example
@@ -1,0 +1,9 @@
+# Cloudflare R2 (S3 互換) への restic バックアップ用設定。
+# このファイルを secrets/.env.r2 にコピーして実値を埋める（.env.r2 は gitignore 済み）。
+
+# <ACCOUNT_ID> と <BUCKET> を置き換える。エンドポイントは R2 概要に表示される S3 API URL。
+RESTIC_REPOSITORY=s3:https://<ACCOUNT_ID>.r2.cloudflarestorage.com/<BUCKET>
+
+# R2 API Token (Object Read & Write) の認証情報
+AWS_ACCESS_KEY_ID=<R2_ACCESS_KEY_ID>
+AWS_SECRET_ACCESS_KEY=<R2_SECRET_ACCESS_KEY>

--- a/secrets/.env.restic-password.example
+++ b/secrets/.env.restic-password.example
@@ -1,0 +1,8 @@
+# restic リポジトリの暗号化パスフレーズ。
+# secrets/.env.restic-password にコピーし、強いランダム値を入れる:
+#   openssl rand -base64 32 > secrets/.env.restic-password
+#
+# !!! 重要 !!!
+# この値を失うと R2 上のバックアップは復号できず復元不能になる。
+# このサーバー以外（パスワードマネージャ等）にも必ず控えること。
+<RANDOM_PASSPHRASE>


### PR DESCRIPTION
## どういう変更か

memos のデータをマシン外（Cloudflare R2）へ毎日バックアップする sidecar コンテナを追加する。

- `backup/`: `restic` + `sqlite3` の常駐コンテナ。`backup.sh` が SQLite を **オンラインバックアップ API** で整合スナップショット化（memos 無停止）し、それ以外の実体（assets 等）と合わせて restic で R2 に暗号化・増分送信する。保持ポリシーは日次7 / 週次4 / 月次6。
- `docker-compose.yml`: `memos-backup` サービスを追加。`memos-data` を read-only でマウントし、`BACKUP_CRON`（既定 `0 4 * * *` JST）でスケジュール実行。
- `secrets/*.example`: R2 接続情報と restic 暗号化パスフレーズのテンプレート。実ファイルは既存の `secrets/.gitignore` 方針で除外。

## なぜ変更するのか

grafana / minecraft 等の「消えても困らない」ローカルデータと違い、memos は失うと困るデータ。compose スタック上の memos に対し、オフサイト・暗号化・世代付きの自動バックアップを安価（R2 無料枠で実質 $0）に用意する。

## 追加の情報

- このブランチは `feat/host-memos`（memos のホスティング追加）の上に積んでいる。memos サービス／ボリュームに依存するため。`feat/host-memos` が main にマージされたら base を main に付け替える。
- 本番で実機検証済み: 初回バックアップで R2 リポジトリ初期化＋1世代取得 → `restic check` エラーなし → R2 からの restore で `PRAGMA integrity_check=ok` まで確認済み。
- `restic` の暗号化パスフレーズは紛失すると復元不能なため、サーバー外にも別途保管している。